### PR TITLE
Eggress ip + db upgrade

### DIFF
--- a/acceptance/database/main.tf
+++ b/acceptance/database/main.tf
@@ -25,7 +25,8 @@ resource "aws_db_instance" "default" {
   max_allocated_storage       = 100
   db_name                     = "disscodatabasetest"
   engine                      = "postgres"
-  engine_version              = "15.2"
+  engine_version              = "16.4"
+  allow_major_version_upgrade = true
   instance_class              = "db.m6g.large"
   publicly_accessible         = true
   db_subnet_group_name        = data.terraform_remote_state.vpc-state.outputs.database_subnet_group

--- a/acceptance/vpc/main.tf
+++ b/acceptance/vpc/main.tf
@@ -9,6 +9,11 @@ provider "aws" {
     }
   }
 }
+
+resource "aws_eip" "k8s-eggress-ip" {
+  domain   = "vpc"
+}
+
 module "dissco-k8s-vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "5.0.0"
@@ -24,7 +29,11 @@ module "dissco-k8s-vpc" {
   create_igw           = true
   enable_dns_hostnames = true
   enable_dns_support   = true
+
+  # Ensure we get a single eggress NAT Gateway with fixed IP
   single_nat_gateway   = true
+  reuse_nat_ips       = true                    # <= Skip creation of EIPs for the NAT Gateways
+  external_nat_ip_ids = aws_eip.k8s-eggress-ip.*.id
 
   # Manage so we can name
   manage_default_network_acl    = true

--- a/acceptance/vpc/outputs.tf
+++ b/acceptance/vpc/outputs.tf
@@ -17,3 +17,8 @@ output "k8s-vpc-id" {
   value       = module.dissco-k8s-vpc.vpc_id
   description = "Vpc id of the k8s virtual network"
 }
+
+output "k8s-eggress-ip" {
+  value       = aws_eip.k8s-eggress-ip.public_ip
+  description = "The eggress ip of the k8s vpc"
+}

--- a/test/database/main.tf
+++ b/test/database/main.tf
@@ -25,7 +25,8 @@ resource "aws_db_instance" "default" {
   max_allocated_storage       = 100
   db_name                     = "disscodatabasetest"
   engine                      = "postgres"
-  engine_version              = "15.2"
+  engine_version              = "16.4"
+  allow_major_version_upgrade = true
   instance_class              = "db.m6g.large"
   publicly_accessible         = true
   db_subnet_group_name        = data.terraform_remote_state.vpc-state.outputs.database_subnet_group

--- a/test/vpc/outputs.tf
+++ b/test/vpc/outputs.tf
@@ -22,3 +22,8 @@ output "db-vpc-id-test" {
   value       = module.dissco-database-vpc.vpc_id
   description = "Vpc id of the database"
 }
+
+output "k8s-eggress-ip" {
+  value       = aws_eip.k8s-eggress-ip.public_ip
+  description = "The eggress ip of the k8s vpc"
+}


### PR DESCRIPTION
This sets up a fixed Egress IP through the a NAT gateway.
To recap all nodes are in a private subnet (can't communicate with the outside).
We already got a load balancer for traffix coming into the cluster and we had a NAT gateway for external traffic.
In this PR I fixed the NAT gateway IP to a separate resource so that if the NAT changes we can reattach the IP (so the IP doesn't change).
This helps if we rebuild the VPC or cluster as external parties wouldn't need to update their firewall (whitelist).
Anyway small change didn't take any downtime so did it on acceptance as well.

Also upgraded the db, we don't use any special functions so this was a low risk update but ensures we keep in the supported window for the coming while.
DB update would also be needed at some point for the other db's 